### PR TITLE
Update the algorithm to handle roles where naming is not supported

### DIFF
--- a/index.html
+++ b/index.html
@@ -249,7 +249,7 @@
     </section>
       <p>The text alternative for a given element is computed as follows:</p>
       <ol>
-        <li id="step1">Initialize:  Set the <code>root node</code> to the given element, the <code>current node</code> to the <code>root node</code>, and the <code>total accumulated text</code> to the empty string ("").</li>
+        <li id="step1">Initialize: Set the <code>root node</code> to the given element, the <code>current node</code> to the <code>root node</code>, and the <code>total accumulated text</code> to the empty string (""). If the <code>root node</code>'s role does not support naming, return the empty string ("").</li>
         <li id="step2">Compute the text alternative for the <code>current node</code>:
           <ol>
             <li id="step2A">If the <code>current node</code> is <a class="termref">hidden</a> <strong>and is not</strong> directly referenced by <code>aria-labelledby</code> or <code>aria-describedby</code>, nor directly referenced by a native host language text alternative <a class="termref">element</a> (e.g. <code>label</code> in HTML) or <a class="termref">attribute</a>, return the empty string.

--- a/index.html
+++ b/index.html
@@ -249,7 +249,7 @@
     </section>
       <p>The text alternative for a given element is computed as follows:</p>
       <ol>
-        <li id="step1">Initialize: Set the <code>root node</code> to the given element, the <code>current node</code> to the <code>root node</code>, and the <code>total accumulated text</code> to the empty string (""). If the <code>root node</code>'s role does not support naming, return the empty string ("").</li>
+        <li id="step1">Set the <code>root node</code> to the given element, the <code>current node</code> to the <code>root node</code>, and the <code>total accumulated text</code> to the empty string (""). If the <code>root node</code>'s role prohibits naming, return the empty string ("").</li>
         <li id="step2">Compute the text alternative for the <code>current node</code>:
           <ol>
             <li id="step2A">If the <code>current node</code> is <a class="termref">hidden</a> <strong>and is not</strong> directly referenced by <code>aria-labelledby</code> or <code>aria-describedby</code>, nor directly referenced by a native host language text alternative <a class="termref">element</a> (e.g. <code>label</code> in HTML) or <a class="termref">attribute</a>, return the empty string.
@@ -386,6 +386,7 @@
                         <h2>Substantive changes since the last public working draft</h2>
 			<ul>
 				<!-- EdNote: After each WD publish, move contents of this list into the next one below.  -->
+				<li>27-June-2019: Add statement allowing for the possibility of naming being prohibited on the root node. Note: This change in and of itself has no implementation impact, but it allows other specifications to optionally prohibit naming for a top-level element. Furthermore, even if this prohibition is made within a specification, that prohibition will not have any impact on calculating name from contents.</li>
 			</ul>
 		</section>
 		<section>


### PR DESCRIPTION
Add a statement to the end of Step 1 ("initialize") stating that if the
root node's role doesn't support naming, return the empty string. At the
present time, this impacts nothing because all roles currently support
naming. If that changes within the ARIA spec, this modification is meant
to accomplish the following:

`<span aria-label="bar">foo</span>`: The span has no name.

`<button><span aria-label="bar">foo</span></button>`: The button's
accessible name is "bar" (but the span itself has no name).

In other words, it prohibits generic elements themselves from getting
names, but preserves the name calculation results authors might be
expecting in currently-deployed content.