### PR TITLE
add name from prohibited

### DIFF
--- a/index.html
+++ b/index.html
@@ -182,14 +182,16 @@
 <section id="mapping_additional_nd" class="normative">
   <h2>Name and Description</h2>
   <p>The starting point of the name and description computation is a <abbr title="Document Object Model">DOM</abbr> <a class="termref">element</a>.  The output is a flat, unstructured string that can be as simple as a single word, or a string of space-separated tokens.  Examples include <code>Save</code> and <code>Reload from disk</code>.</p>
-  <p>An important factor is the <a class="termref">element</a>'s <a class="termref">role</a>, that determines which content contributes to the name string.  Roles have a <code>nameFrom</code> <abbr title="Resource Description Framework">RDF</abbr> property, with two possible values:  </p>
+  <p>An important factor is the <a class="termref">element</a>'s <a class="termref">role</a>, that determines which content contributes to the name string.  Roles have a <code>nameFrom</code> <abbr title="Resource Description Framework">RDF</abbr> property, with three possible values:  </p>
   <dl class="runin">
     <dt>author</dt>
     <dd>name is generated from values provided by the author in explicit markup features such as the <code>aria-label</code> and <code>aria-labelledby</code> <a class="termref">attribute</a>, or a host language labeling mechanism, such as the <code>alt</code> or <code>title</code> <a class="termref">attribute</a> in <abbr title="Hypertext Markup Language">HTML</abbr>, or the <code>desc</code> <a class="termref">element</a> in <abbr title="Scalable Vector Graphics">SVG</abbr>. </dd>
     <dt>contents</dt>
     <dd>name is generated from the <a class="termref" data-lt="text node">Text nodes</a> associated with the <a class="termref">element</a>. Although this may be allowed in addition to "author" in some <a class="termref">roles</a>, "content" is used only if higher priority "author" features are not provided. Priority is defined by the <a href="#mapping_additional_nd_te">accessible name and description computation</a> algorithm.</dd>
+    <dt>prohibited</dt>
+    <dd>the element has no name. Authors <em class="rfc2119" title="MUST NOT">MUST NOT</em> use the <a href="#aria-label" class="property-reference"><code>aria-label</code></a> or <a href="#aria-labelledby" class="property-reference"><code>aria-labelledby</code></a> attributes to name the element.</dd>
   </dl>
-  <p>The <cite><a class="specref" href="#">Accessible Rich Internet Applications (WAI-ARIA) 1.2</a></cite> [[!WAI-ARIA]] specification provides lists of roles that support <a class="specref" href="#namefromauthor">name from author</a> and <a class="specref" href="#namefromcontent">name from content</a>. </p>
+  <p>The <cite><a class="specref" href="#">Accessible Rich Internet Applications (WAI-ARIA) 1.2</a></cite> [[!WAI-ARIA]] specification provides lists of <a class="specref" href="#namefromauthor">roles that support name from author</a>, <a class="specref" href="#namefromcontent">roles that support name from content</a> and <a class="specref" href="#namefromprohibited">roles that cannot be named</a>.</p>
   <section id="mapping_additional_nd_name">
     <h3>Name Computation</h3>
     <p><a class="termref">User agents</a> MUST compute an <a class="termref">accessible name</a> using the rules outlined below in the section titled <a href="#mapping_additional_nd_te">Accessible Name and Description Computation</a>.</p>


### PR DESCRIPTION
As discussed on https://github.com/w3c/accname/issues/70 let me know if i need to change anything, pretty much copy pasted since i thought it described it quite well. i also added a link to prohibited roles.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/billybonks/accname/pull/71.html" title="Last updated on Aug 25, 2020, 8:06 PM UTC (1f451d6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/accname/71/d30df64...billybonks:1f451d6.html" title="Last updated on Aug 25, 2020, 8:06 PM UTC (1f451d6)">Diff</a>