### PR TITLE
Dynamically defining exports from common

### DIFF
--- a/index.html
+++ b/index.html
@@ -144,17 +144,19 @@
   var definitions_to_export = [ "accessible name", "accessible description" ];
   function exportDefinitions( utils, content, url ){
     var $dfnDiv = document.createElement("div"),
-        $dfns;
+        $dfns,
+        i;
     $dfnDiv.innerHTML = content;
     $dfns = $dfnDiv.querySelectorAll('dfn:not([data-export])');
-    $dfns.forEach(function($el){
-      var text = $el.innerText.toLowerCase();
+    i = $dfns.length;
+    while( i-- )
+    {
+      var text = $dfns[i].innerText.toLowerCase();
       if ( definitions_to_export.indexOf( text ) > -1 )
       {
-        $el.dataset.export = "";
+        $dfns[i].dataset.export = "";
       }
-      //return $el;
-    });
+    }
     return $dfnDiv.innerHTML;
   }
 </script>
@@ -190,7 +192,7 @@
 </section>
 <section id="glossary">
   <h2>Important Terms</h2>
-  <div data-include="common/terms.html" data-oninclude="exportDefinitions restrictReferences"></div>
+  <div data-include="common/terms.html" data-oninclude="restrictReferences exportDefinitions"></div>
 </section>
 <section id="mapping_additional_nd" class="normative">
   <h2>Name and Description</h2>

--- a/index.html
+++ b/index.html
@@ -146,6 +146,25 @@
     preProcess: [ linkCrossReferences ]
   }
 </script>
+<script>
+  var definitions_to_export = [ "accessible name", "accessible description" ];
+  function exportDefinitions( utils, content, url ){
+    var $dfnDiv = document.createElement("div"),
+        $dfns;
+    $dfnDiv.innerHTML = content;
+    $dfns = $dfnDiv.querySelector('dfn:not([data-export])');
+    $dfns.forEach(function($el){
+      var text = $el.innerText.toLowerCase();
+      console.log( text, definitions_to_export.indexOf( text ) );
+      if ( definitions_to_export.indexOf( text ) > -1 )
+      {
+        $el.dataset.export = "";
+      }
+      //return $el;
+    });
+    return content;
+  }
+</script>
 </head>
 <body>
 <section id="abstract">
@@ -176,7 +195,7 @@
 </section>
 <section id="glossary">
   <h2>Important Terms</h2>
-  <div data-include="common/terms.html" data-oninclude="restrictReferences"></div>
+  <div data-include="common/terms.html" data-oninclude="restrictReferences exportDefinitions"></div>
 </section>
 <section id="mapping_additional_nd" class="normative">
   <h2>Name and Description</h2>
@@ -195,7 +214,7 @@
   </section>
   <section id="mapping_additional_nd_description">
     <h3>Description Computation</h3>
-    <p>If <a class="property-reference" href="#aria-describedby"><code>aria-describedby</code></a> is present, <a class="termref">user agents</a> MUST compute the accessible description by concatenating the text alternatives for elements referenced by an <code>aria-describedby</code> attribute on the current element. The text alternatives for the referenced elements are computed using a number of methods, outlined below in the section titled <a href="#mapping_additional_nd_te">Accessible Name and Description Computation</a>. </p>
+    <p>If <a class="property-reference" href="#aria-describedby"><code>aria-describedby</code></a> is present, <a class="termref">user agents</a> MUST compute the <a class="termref">accessible description</a> by concatenating the text alternatives for elements referenced by an <code>aria-describedby</code> attribute on the current element. The text alternatives for the referenced elements are computed using a number of methods, outlined below in the section titled <a href="#mapping_additional_nd_te">Accessible Name and Description Computation</a>. </p>
   </section>
   <section id="mapping_additional_nd_te">
     <h3>Accessible Name and Description Computation</h3>

--- a/index.html
+++ b/index.html
@@ -195,7 +195,7 @@
 </section>
 <section id="glossary">
   <h2>Important Terms</h2>
-  <div data-include="common/terms.html" data-oninclude="restrictReferences exportDefinitions"></div>
+  <div data-include="common/terms.html" data-oninclude="exportDefinitions restrictReferences"></div>
 </section>
 <section id="mapping_additional_nd" class="normative">
   <h2>Name and Description</h2>

--- a/index.html
+++ b/index.html
@@ -3,11 +3,8 @@
 <head>
 <title>Accessible Name and Description Computation 1.2</title>
 <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
-<script src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove" defer></script>
-<script src="common/script/resolveReferences.js" class="remove"></script>
-<script src="common/biblio.js" class="remove"></script>
 <link href="common/css/common.css" rel="stylesheet" type="text/css"/>
-
+<script src="common/script/resolveReferences.js" class="remove"></script>
 <script class="remove">
   var respecConfig = {
 	github: "w3c/accname",
@@ -140,9 +137,6 @@
        "FPWD": "https://www.w3.org/TR/core-aam-1.2/",
        "REC": "https://www.w3.org/TR/core-aam-1.2/"
     },
-
-    localBiblio: biblio,
-    
     preProcess: [ linkCrossReferences ]
   }
 </script>
@@ -152,10 +146,9 @@
     var $dfnDiv = document.createElement("div"),
         $dfns;
     $dfnDiv.innerHTML = content;
-    $dfns = $dfnDiv.querySelector('dfn:not([data-export])');
+    $dfns = $dfnDiv.querySelectorAll('dfn:not([data-export])');
     $dfns.forEach(function($el){
       var text = $el.innerText.toLowerCase();
-      console.log( text, definitions_to_export.indexOf( text ) );
       if ( definitions_to_export.indexOf( text ) > -1 )
       {
         $el.dataset.export = "";
@@ -165,6 +158,8 @@
     return $dfnDiv.innerHTML;
   }
 </script>
+<script src="common/biblio.js" class="remove"></script>
+<script src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove" defer></script>
 </head>
 <body>
 <section id="abstract">

--- a/index.html
+++ b/index.html
@@ -162,7 +162,7 @@
       }
       //return $el;
     });
-    return content;
+    return $dfnDiv.innerHTML;
   }
 </script>
 </head>


### PR DESCRIPTION
Related to #84, I had an idea that would not require a wholesale overhaul of the definition export. Curious for your thoughts @marcoscaceres @jnurthen

This commit:

* Defines the terms to be exported in a variable `definitions_to_export`
* Parses the "common" include using the `oninclude` hook and adds the `data-export` param to the existing `dfn` elements that match the values in that array.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Aug 25, 2020, 8:06 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Frawcdn.githack.com%2Fw3c%2Faccname%2F80f82400d396e8239b8632fdefc91dc433c3d069%2Findex.html%3FisPreview%3Dtrue)

```

😭  Sorry, there was an error generating the HTML. Please report this issue!
[36mSpecification: https://rawcdn.githack.com/w3c/accname/80f82400d396e8239b8632fdefc91dc433c3d069/index.html?isPreview=true&publishDate=2020-08-25[39m
[36mReSpec version: 25.6.0[39m
[36mFile a bug: https://github.com/w3c/respec/[39m
[36mError: Error: Evaluation failed: Timeout: document.respecIsReady didn't resolve in 29054ms.[39m
[36m    at ExecutionContext._evaluateInternal (/u/spec-generator/node_modules/puppeteer/lib/cjs/puppeteer/common/ExecutionContext.js:217:19)[39m
[36m    at runMicrotasks (<anonymous>)[39m
[36m    at processTicksAndRejections (internal/process/task_queues.js:97:5)[39m
[36m    at async ExecutionContext.evaluate (/u/spec-generator/node_modules/puppeteer/lib/cjs/puppeteer/common/ExecutionContext.js:106:16)[39m
[36m    at async generateHTML (/u/spec-generator/node_modules/respec/tools/respecDocWriter.js:128:12)[39m
[36m    at async fetchAndWrite (/u/spec-generator/node_modules/respec/tools/respecDocWriter.js:95:18)[39m
[36m    at async Object.generate [as respec] (/u/spec-generator/generators/respec.js:14:20)[39m
[36m    at async generate (/u/spec-generator/server.js:90:29)[39m
[36m[39m
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/accname%2385.)._
</details>
