### PR TITLE
Added reference to HTML-AAM on step 2D.

### DIFF
--- a/index.html
+++ b/index.html
@@ -308,7 +308,7 @@
 &lt;/ul&gt;</code></pre>
                 </details></div>
             </li>
-            <li id="step2D">Otherwise, if the <code>current node</code>'s native markup provides an <a class="termref">attribute</a> (e.g. <code>title</code>) or <a class="termref">element</a> (e.g. HTML <code>label</code>) that defines a text alternative, return that alternative in the form of a <code>flat string</code> as defined by the host language, unless the element is marked as presentational (<code>role="presentation"</code> or <code>role="none"</code>).
+            <li id="step2D">Otherwise, if the <code>current node</code>'s native markup provides an <a class="termref">attribute</a> (e.g. <code>title</code>) or <a class="termref">element</a> (e.g. HTML <code>label</code>) that defines a text alternative, return that alternative in the form of a <code>flat string</code> as defined by the host language, unless the element is marked as presentational (<code>role="presentation"</code> or <code>role="none"</code>). See <a href="https://www.w3.org/TR/html-aam/">HTML-AAM</a> for detail on HTML markup that defines a text alternative.
               <div><details>
                 <summary>Comment:</summary>
                 <p>For example, in <abbr title="Hypertext Markup Language">HTML</abbr>, the <code>img</code> element's <code>alt</code> attribute defines a text alternative string, and the <code>label</code> element provides text for the referenced form element.  In <abbr title="SVG2">SVG2</abbr>, the <code>desc</code> and <code>title</code> elements provide a description of their parent element. </p>


### PR DESCRIPTION
- Added a reference to the [HTML-AAM](https://www.w3.org/TR/html-aam/) on step 2D. 

The HTML-AAM is relevant to accessible name computation for HTML (step 2D in particular) but is not linked anywhere in the spec. This was brought up in [issue #36](https://github.com/w3c/accname/issues/36).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Aug 13, 2020, 11:50 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Frawcdn.githack.com%2FOisinNolan%2Faccname%2F5571f3fbafa555982aa14aeb3b6bf3a220f004a4%2Findex.html%3FisPreview%3Dtrue)

```

😭  Sorry, there was an error generating the HTML. Please report this issue!
[36mSpecification: https://rawcdn.githack.com/OisinNolan/accname/5571f3fbafa555982aa14aeb3b6bf3a220f004a4/index.html?isPreview=true&publishDate=2020-08-13[39m
[36mReSpec version: 25.6.0[39m
[36mFile a bug: https://github.com/w3c/respec/[39m
[36mError: Error: Evaluation failed: Timeout: document.respecIsReady didn't resolve in 28939ms.[39m
[36m    at ExecutionContext._evaluateInternal (/u/spec-generator/node_modules/puppeteer/lib/cjs/puppeteer/common/ExecutionContext.js:217:19)[39m
[36m    at runMicrotasks (<anonymous>)[39m
[36m    at processTicksAndRejections (internal/process/task_queues.js:97:5)[39m
[36m    at async ExecutionContext.evaluate (/u/spec-generator/node_modules/puppeteer/lib/cjs/puppeteer/common/ExecutionContext.js:106:16)[39m
[36m    at async generateHTML (/u/spec-generator/node_modules/respec/tools/respecDocWriter.js:128:12)[39m
[36m    at async fetchAndWrite (/u/spec-generator/node_modules/respec/tools/respecDocWriter.js:95:18)[39m
[36m    at async Object.generate [as respec] (/u/spec-generator/generators/respec.js:14:20)[39m
[36m    at async generate (/u/spec-generator/server.js:90:29)[39m
[36m[39m
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/accname%2387.)._
</details>
