### PR TITLE
Removed redundant line from 2.C.

### DIFF
--- a/index.html
+++ b/index.html
@@ -317,7 +317,6 @@
             <li id="step2E">Otherwise, if the <code>current node</code> is a control embedded within the label (e.g. the <code>label</code> element in HTML or any element directly referenced by <code>aria-labelledby</code>) for another <a class="termref">widget</a>, where the user can adjust the embedded control's value, then include the embedded control as part of the text alternative in the following manner:
               <ul>
                 <li>If the embedded control has role <a class="role-reference" href="#textbox">textbox</a>, return its value.</li>
-                <li>If the embedded control has role menu <a class="role-reference" href="#button">button</a>, return the text alternative of the button.</li>
                 <li>If the embedded control has role <a class="role-reference" href="#combobox">combobox</a> or <a class="role-reference" href="#listbox">listbox</a>, return the text alternative of the chosen <a class="role-reference" href="#option">option</a>.</li>
                 <li>If the embedded control has role <a class="role-reference" href="#range">range</a> (e.g., a <a class="role-reference" href="#spinbutton">spinbutton</a> or <a class="role-reference" href="#slider">slider</a>):
                   <ul>


### PR DESCRIPTION
The second bullet point under step 2.E. states `If the embedded control has role menu button, return the text alternative of the button.`.

I don't see any reason to distinguish `menu button` from `button` here. I believe that if we are to remove the bullet point quoted above (as is done in this PR) then such `menu button`s would simply be handled by 2.F, given that nodes with role `button` allow name from content.

The motivation here is to simplify the spec by removing redundancy.

If I have missed something here please let me know, thanks! :)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/OisinNolan/accname/pull/92.html" title="Last updated on May 16, 2021, 3:04 PM UTC (49caffd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/accname/92/9e7c441...OisinNolan:49caffd.html" title="Last updated on May 16, 2021, 3:04 PM UTC (49caffd)">Diff</a>