### PR TITLE
Only use accumulated text that is not empty

### DIFF
--- a/index.html
+++ b/index.html
@@ -271,7 +271,7 @@
                         <li id="step2B.ii.c">Append the <code>result</code>, with a space, to the <code>accumulated text</code>.</li>
                       </ol>
                     </li>
-                    <li id="step2B.iii">Return the <code>accumulated text</code>.</li>
+                    <li id="step2B.iii">Return the <code>accumulated text</code> if it is not the empty string ("").</li>
                   </ol>
                 </li>
               </ul>
@@ -350,7 +350,7 @@
                     <li id="step2F.iii.c">Append the <code>result</code> to the <code>accumulated text</code>. </li>
                   </ol>
                 </li>
-                <li id="step2F.iv">Return the <code>accumulated text</code>.</li>
+                <li id="step2F.iv">Return the <code>accumulated text</code> if it is not the empty string ("").</li>
               </ol>
               <p><strong>Important</strong>:  Each <a class="termref">node</a> in the subtree is consulted only once. If text has been collected from a descendant, but is referenced by another IDREF in some descendant node, then that second, or subsequent, reference is not followed. This is done to avoid infinite loops.  </p>
               <div><details>


### PR DESCRIPTION
This seemed like the simplest way to resolve #72.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kasperisager/accname/pull/112.html" title="Last updated on Feb 19, 2021, 3:07 PM UTC (fe3a05d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/accname/112/2399041...kasperisager:fe3a05d.html" title="Last updated on Feb 19, 2021, 3:07 PM UTC (fe3a05d)">Diff</a>