### PR TITLE
updated step 2c prose for consistency

### DIFF
--- a/index.html
+++ b/index.html
@@ -142,7 +142,7 @@
     preProcess: [ linkCrossReferences ],
 	  postProcess: [ ],
     //Pointing to the 1.2 versions but should remove the version in the publishing branch
-	  xref: ["core-aam-1.2", "wai-aria-1.2"]  
+	  xref: ["core-aam-1.2", "wai-aria-1.2"]
   }
 </script>
 </head>
@@ -286,7 +286,7 @@
                 </pre>
               </details></div>
             </li>
-            <li id="step2C">Otherwise, if the <code>current node</code> is a control embedded within the label (e.g. the <code>label</code> element in HTML or any element directly referenced by <code>aria-labelledby</code>) for another <a class="termref">widget</a>, where the user can adjust the embedded control's value, then include the embedded control as part of the text alternative in the following manner:
+            <li id="step2C">Otherwise, if the <code>current node</code> is a control embedded within the label (e.g. the <code>label</code> element in HTML or any element directly referenced by <code>aria-labelledby</code>) for another <a class="termref">widget</a>, where the user can adjust the embedded control's value, then return the embedded control as part of the text alternative in the following manner:
               <ul>
                 <li>If the embedded control has role <a class="role-reference" href="#textbox">textbox</a>, return its value.</li>
                 <li>If the embedded control has role menu <a class="role-reference" href="#button">button</a>, return the text alternative of the button.</li>


### PR DESCRIPTION
Resolves #126 

If merged, this PR updates step 2C for clarity- replaces the word "include" with "return" 

Changed: 
`then include the embedded control as part of the text alternative in the following manner:`

to

`then return the embedded control as part of the text alternative in the following manner:`


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/accname/pull/129.html" title="Last updated on May 16, 2021, 3:51 PM UTC (8e1d42f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/accname/129/bb7d784...8e1d42f.html" title="Last updated on May 16, 2021, 3:51 PM UTC (8e1d42f)">Diff</a>