### PR TITLE
removed menu button example from step 2C

### DIFF
--- a/index.html
+++ b/index.html
@@ -142,7 +142,7 @@
     preProcess: [ linkCrossReferences ],
 	  postProcess: [ ],
     //Pointing to the 1.2 versions but should remove the version in the publishing branch
-	  xref: ["core-aam-1.2", "wai-aria-1.2"]  
+	  xref: ["core-aam-1.2", "wai-aria-1.2"]
   }
 </script>
 </head>
@@ -289,7 +289,6 @@
             <li id="step2C">Otherwise, if the <code>current node</code> is a control embedded within the label (e.g. the <code>label</code> element in HTML or any element directly referenced by <code>aria-labelledby</code>) for another <a class="termref">widget</a>, where the user can adjust the embedded control's value, then include the embedded control as part of the text alternative in the following manner:
               <ul>
                 <li>If the embedded control has role <a class="role-reference" href="#textbox">textbox</a>, return its value.</li>
-                <li>If the embedded control has role menu <a class="role-reference" href="#button">button</a>, return the text alternative of the button.</li>
                 <li>If the embedded control has role <a class="role-reference" href="#combobox">combobox</a> or <a class="role-reference" href="#listbox">listbox</a>, return the text alternative of the chosen <a class="role-reference" href="#option">option</a>.</li>
                 <li>If the embedded control has role <a class="role-reference" href="#range">range</a> (e.g., a <a class="role-reference" href="#spinbutton">spinbutton</a> or <a class="role-reference" href="#slider">slider</a>):
                   <ul>


### PR DESCRIPTION
Resolves #104 

If merged, this PR would remove the menu button example in step 2C. 

After reviewing the role list (there is a [role of menu](https://www.w3.org/TR/wai-aria/#menu) but not menubutton), the [authoring example for menu button](https://www.w3.org/TR/2016/WD-wai-aria-practices-1.1-20161214/examples/menu-button/menu-button-1/menu-button-1.html), and looking at the results of the accname prototype test for the sample code, this line doesn't make sense.  I don't think the user can adjust the embedded control's value, and the text content of the button would already be the accessible name of the menu itself.

Let me know if I'm missing something!


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/accname/pull/130.html" title="Last updated on May 16, 2021, 5:05 PM UTC (a2a7039)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/accname/130/bb7d784...a2a7039.html" title="Last updated on May 16, 2021, 5:05 PM UTC (a2a7039)">Diff</a>