### PR TITLE
Specprod options

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -4,11 +4,27 @@ on:
   push:
     branches:
       - main
+      - stable
   pull_request: {}
 
 jobs:
   validate-and-publish:
     name: Validate and publish to gh-pages
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest # only linux supported at present
+    steps:
+      - uses: actions/checkout@v2
+      - uses: w3c/spec-prod@v2
+        with:
+          GH_PAGES_BRANCH: gh-pages
+          VALIDATE_WEBIDL: false
+          VALIDATE_MARKUP: false
+          BUILD_FAIL_ON: nothing
+          GH_PAGES_BUILD_OVERRIDE: |
+            lint: false
+  publish-tr:
+    name: Publish to TR from stable branch
+    if: github.ref == 'refs/heads/stable'
     runs-on: ubuntu-latest # only linux supported at present
     steps:
       - uses: actions/checkout@v2
@@ -16,11 +32,5 @@ jobs:
         with:
           W3C_ECHIDNA_TOKEN: ${{ secrets.ECHIDNA_TOKEN }}
           W3C_WG_DECISION_URL: https://lists.w3.org/Archives/Public/public-aria-admin/2018Sep/0011.html
-          GH_PAGES_BRANCH: gh-pages
-          VALIDATE_WEBIDL: false
-          VALIDATE_MARKUP: false
-          BUILD_FAIL_ON: nothing
-          GH_PAGES_BUILD_OVERRIDE: |
-            lint: false
           W3C_BUILD_OVERRIDE: |
             specStatus: WD


### PR DESCRIPTION
turn off optional checks when publishing editors' drafts
turn on automatic WD publication