### PR TITLE
Fixed handling of surrounding whitespace for CSS pseudo elements, inline and block level elements, and embedded widgets.

### DIFF
--- a/index.html
+++ b/index.html
@@ -490,6 +490,9 @@
               <div class="note">
                 <p>This step can apply to the child nodes themselves, which means the computation is recursive and results in text collected from all the elements in the <code>current node</code>'s subtree, no matter how deep it is. However, any given descendant [=nodes|node's=] text alternative can result from higher precedent markup described in steps B through D above, where "Namefrom: author" attributes provide the text alternative for the entire subtree. </p>
               </div>
+              <div class="note" id="note-concatenate-inline-contents-with-space">
+                <p>18 January 2024: The ARIA Working Group is considering the feasibility of joining text strings with and without spaces, depending on the CSS <code>display</code> value of the <code>current node</code>, and its adjacent nodes and pseudo-elements. The ongoing discussion is in <a href="https://github.com/w3c/accname/issues/225">AccName #225</a>.</p>
+              </div>
             </li>
             <li id="comp_text_node"><span id="step2G"><!-- Don't link to this legacy numbered ID. --></span><em>Text Node:</em> Otherwise, if the <code>current node</code> is a Text [=Node=], return its textual contents.</li>
             <li id="comp_recursive_name_from_content"><span id="step2H"><!-- Don't link to this legacy numbered ID. --></span><em>Recursive Name From Content:</em> Otherwise, if the <code>current node</code> is a descendant of an element whose <a class="termref">Accessible Name</a> or <a class="termref">Accessible Description</a> is being computed, and contains descendants, proceed to <a href="#comp_name_from_content_reset">Name From Content Reset</a>.</li>


### PR DESCRIPTION
This change adds logic to handle block level and inline elements where it is necessary to add a space at the beginning or end of accumulated text in order to return the most accessible names and descriptions for the accessibility tree.

Before merging, we need to confirm:
- [ ] Test coverage (add link to tests)
- Need updates to browsers?
    - [ ] Chrome: yes/no
    - [ ] Safari: yes/no
    - [ ] Firefox: yes/no

[Update: assuming this stays as a note only, there will be no WPT or implementation issues... Those would come with #225. –@cookiecrook]


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/accname/pull/168.html" title="Last updated on Jan 19, 2024, 2:43 AM UTC (8ecf859)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/accname/168/a00a582...8ecf859.html" title="Last updated on Jan 19, 2024, 2:43 AM UTC (8ecf859)">Diff</a>