### PR TITLE
fix: revert changes introduced by bb65de

### DIFF
--- a/index.html
+++ b/index.html
@@ -349,7 +349,6 @@
                     <li>Otherwise, if the <code>aria-valuenow</code> property is present, return its value,</li>
                     <li>Otherwise, use the value as specified by a host language attribute. </li>
                   </ul>
-                  <p>Append the <code>result</code> of each step above, with a space preceding and following, to the <code>accumulated text</code>.</p>
                 </li>
               </ul>
               <div><details>
@@ -391,18 +390,8 @@
                 <li id="step2F.i">Set the <code>accumulated text</code> to the empty string.</li>
                 <li id="step2F.ii">Check for <abbr title="Cascading Style Sheets">CSS</abbr> generated textual content associated with the <code>current node</code> and include it in the <code>accumulated text</code>. The <abbr title="Cascading Style Sheets">CSS</abbr> <a href="https://www.w3.org/TR/CSS2/generate.html#before-after-content"><code>:before</code> and <code>:after</code></a> pseudo elements [[!CSS2]] can provide textual content for [=element|elements=] that have a content model.
                   <ul>
-                    <li>For <code>:before</code> pseudo elements, <a class="termref">User agents</a> MUST prepend <abbr title="Cascading Style Sheets">CSS</abbr> textual content to the textual content of the <code>current node</code> as follows:
-                    <ul>
-                      <li>If the pseudo element includes spacing between it and the textual content of the <code>current node</code>, <a class="termref">User agents</a> MUST prepend <abbr title="Cascading Style Sheets">CSS</abbr> textual content, with a space following, to the textual content of the <code>current node</code>. </li>
-                      <li>Otherwise, <a class="termref">User agents</a> MUST prepend <abbr title="Cascading Style Sheets">CSS</abbr> textual content, without a space following, to the textual content of the <code>current node</code>. </li>
-                    </ul>
-                    </li>
-                    <li>For <code>:after</code> pseudo elements, <a class="termref">User agents</a> MUST append <abbr title="Cascading Style Sheets">CSS</abbr> textual content to the textual content of the <code>current node</code> as follows:
-                    <ul>
-                      <li>If the pseudo element includes spacing between the textual content of the <code>current node</code> and itself, <a class="termref">User agents</a> MUST append <abbr title="Cascading Style Sheets">CSS</abbr> textual content, with a space preceding, to the textual content of the <code>current node</code>. </li>
-                      <li>Otherwise, <a class="termref">User agents</a> MUST append <abbr title="Cascading Style Sheets">CSS</abbr> textual content, without a space preceding, to the textual content of the <code>current node</code>. </li>
-                    </ul>
-                    </li>
+                    <li>For <code>:before</code> pseudo elements, <a class="termref">User agents</a> MUST prepend <abbr title="Cascading Style Sheets">CSS</abbr> textual content, without a space, to the textual content of the <code>current node</code>. </li>
+                    <li>For <code>:after</code> pseudo elements, <a class="termref">User agents</a> MUST append <abbr title="Cascading Style Sheets">CSS</abbr>  textual content, without a space, to the textual content of the <code>current node</code>. </li>
                   </ul>
                 </li>
                 <li id="step2F.iii">For each child node of the <code>current node</code>:


### PR DESCRIPTION
https://github.com/w3c/accname/commit/bb65de313a893e3a4b9d4522deb1d049c114584e introduced changes which are part of https://github.com/w3c/accname/pull/168 and have not yet been agreed. This PR reverts those changes


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/accname/pull/172.html" title="Last updated on Oct 6, 2022, 10:32 PM UTC (85dd567)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/accname/172/bb65de3...85dd567.html" title="Last updated on Oct 6, 2022, 10:32 PM UTC (85dd567)">Diff</a>