### PR TITLE
Editorial: Fix unnecessary nesting

### DIFF
--- a/index.html
+++ b/index.html
@@ -354,21 +354,17 @@
                 </pre>
               </details></div>
             </li>
-            <li id="comp_labelledby_overall" name="step2B">Otherwise:
+            <li id="comp_labelledby" name="step2B"><em>LabelledBy:</em> Otherwise, if the <code>current node</code> has an <code>aria-labelledby</code> [=attribute=] that contains at least one valid IDREF, and the <code>current node</code> is not already part of an ongoing <code>aria-labelledby</code> or <code>aria-describedby</code> traversal, process its IDREFs in the order they occur:
               <ol>
-                <li id="comp_labelledby"><em>LabelledBy:</em> If the <code>current node</code> has an <code>aria-labelledby</code> [=attribute=] that contains at least one valid IDREF, and the <code>current node</code> is not already part of an ongoing <code>aria-labelledby</code> or <code>aria-describedby</code> traversal, process its IDREFs in the order they occur: </li>
+                <li id="comp_labelledby_reset" name="step2B.i">Set the <code>accumulated text</code> to the empty string.</li>
+                <li id="comp_labelledby_foreach" name="step2B.ii">For each IDREF:
                   <ol>
-                    <li id="comp_labelledby_reset" name="step2B.i">Set the <code>accumulated text</code> to the empty string.</li>
-                    <li id="comp_labelledby_foreach" name="step2B.ii">For each IDREF:
-                      <ol>
-                        <li id="comp_labelledby_set_current" name="step2B.ii.a">Set the <code>current node</code> to the node referenced by the IDREF.</li>
-                        <li id="comp_labelledby_recursion" name="step2B.ii.b"><em>LabelledBy Recursion:</em> Compute the text alternative of the <code>current node</code> beginning with the overall <a href="#comp_computation">Computation</a> step. Set the <code>result</code> to that text alternative.</li>
-                        <li id="comp_labelledby_append" name="step2B.ii.c">Append a space character and the <code>result</code> to the <code>accumulated text</code>.</li>
-                      </ol>
-                    </li>
-                    <li id="comp_labelledby_return" name="step2B.iii">Return the <code>accumulated text</code> if it is not the empty string ("").</li>
+                    <li id="comp_labelledby_set_current" name="step2B.ii.a">Set the <code>current node</code> to the node referenced by the IDREF.</li>
+                    <li id="comp_labelledby_recursion" name="step2B.ii.b"><em>LabelledBy Recursion:</em> Compute the text alternative of the <code>current node</code> beginning with the overall <a href="#comp_computation">Computation</a> step. Set the <code>result</code> to that text alternative.</li>
+                    <li id="comp_labelledby_append" name="step2B.ii.c">Append a space character and the <code>result</code> to the <code>accumulated text</code>.</li>
                   </ol>
                 </li>
+                <li id="comp_labelledby_return" name="step2B.iii">Return the <code>accumulated text</code> if it is not the empty string ("").</li>
               </ol>
               <div><details>
                 <summary>Comment:</summary>


### PR DESCRIPTION
I was just looking at the AccName calculation, and the "2B: Labelledby" step look unnecessarily nested with an extra "li". So I removed it.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/accname/pull/189.html" title="Last updated on Mar 2, 2023, 9:12 PM UTC (caadab3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/accname/189/bf6fde1...caadab3.html" title="Last updated on Mar 2, 2023, 9:12 PM UTC (caadab3)">Diff</a>