### PR TITLE
Editorial: `name` not allowed on a `li` element

### DIFF
--- a/index.html
+++ b/index.html
@@ -401,7 +401,7 @@
                 <li id="comp_labelledby_reset"><span id="step2B.i"><!-- Don't link to this legacy numbered ID. --></span> Set the <code>accumulated text</code> to the empty string.</li>
                 <li id="comp_labelledby_foreach"><span id="step2B.ii"><!-- Don't link to this legacy numbered ID. --></span>For each IDREF:
                   <ol>
-                    <li id="comp_labelledby_set_current"><span id="step2B.ii.a"><!-- Don't link to this legacy numbered ID. --></span> the <code>current node</code> to the node referenced by the IDREF.</li>
+                    <li id="comp_labelledby_set_current"><span id="step2B.ii.a"><!-- Don't link to this legacy numbered ID. --></span>Set the <code>current node</code> to the node referenced by the IDREF.</li>
                     <li id="comp_labelledby_recursion"><span id="step2B.ii.b"><!-- Don't link to this legacy numbered ID. --></span><em>LabelledBy Recursion:</em> Compute the text alternative of the <code>current node</code> beginning with the overall <a href="#comp_computation">Computation</a> step. Set the <code>result</code> to that text alternative.</li>
                     <li id="comp_labelledby_append"><span id="step2B.ii.c"><!-- Don't link to this legacy numbered ID. --></span> a space character and the <code>result</code> to the <code>accumulated text</code>.</li>
                   </ol>

--- a/index.html
+++ b/index.html
@@ -357,10 +357,10 @@
       <h4>Computation steps</h4>
       <p>The text alternative for a given element is computed as follows:</p>
       <ol>
-        <li id="comp_init"><span id="step1"></span><em>Initialization:</em> Set the <code>root node</code> to the given element, the <code>current node</code> to the <code>root node</code>, and the <code>total accumulated text</code> to the empty string (""). If the <code>root node</code>'s role prohibits naming, return the empty string ("").</li>
-        <li id="comp_computation"><span id="step2"></span><em>Computation:</em> Compute the text alternative for the <code>current node</code>:
+        <li id="comp_init"><span id="step1"><!-- Don't link to this legacy numbered ID. --></span><em>Initialization:</em> Set the <code>root node</code> to the given element, the <code>current node</code> to the <code>root node</code>, and the <code>total accumulated text</code> to the empty string (""). If the <code>root node</code>'s role prohibits naming, return the empty string ("").</li>
+        <li id="comp_computation"><span id="step2"><!-- Don't link to this legacy numbered ID. --></span><em>Computation:</em> Compute the text alternative for the <code>current node</code>:
           <ol>
-            <li id="comp_hidden_not_referenced"><span id="step2A"></span><em>Hidden Not Referenced:</em> If the <code>current node</code> is <span class="informative">[=element/hidden=]</span> <strong>and is</strong>:
+            <li id="comp_hidden_not_referenced"><span id="step2A"><!-- Don't link to this legacy numbered ID. --></span><em>Hidden Not Referenced:</em> If the <code>current node</code> is <span class="informative">[=element/hidden=]</span> <strong>and is</strong>:
             <ol>
               <li><strong>Not</strong> part of an <code>aria-labelledby</code> or <code>aria-describedby</code> traversal, where the node directly referenced by that relation was hidden.</li>
               <li><strong>Nor</strong> part of a native host language text alternative <a class="termref">element</a> (e.g. <code>label</code> in HTML) or <a class="termref">attribute</a> traversal, where the root of that traversal was hidden.</li>
@@ -396,17 +396,17 @@
 &lt;/element2&gt;</code>
               </aside>
             </li>
-            <li id="comp_labelledby"><span id="step2B"></span><em>LabelledBy:</em> Otherwise, if the <code>current node</code> has an <code>aria-labelledby</code> [=attribute=] that contains at least one valid IDREF, and the <code>current node</code> is not already part of an ongoing <code>aria-labelledby</code> or <code>aria-describedby</code> traversal, process its IDREFs in the order they occur:
+            <li id="comp_labelledby"><span id="step2B"><!-- Don't link to this legacy numbered ID. --></span><em>LabelledBy:</em> Otherwise, if the <code>current node</code> has an <code>aria-labelledby</code> [=attribute=] that contains at least one valid IDREF, and the <code>current node</code> is not already part of an ongoing <code>aria-labelledby</code> or <code>aria-describedby</code> traversal, process its IDREFs in the order they occur:
               <ol>
-                <li id="comp_labelledby_reset"><span id="step2B.i"></span> the <code>accumulated text</code> to the empty string.</li>
-                <li id="comp_labelledby_foreach"><span id="step2B.ii"></span> each IDREF:
+                <li id="comp_labelledby_reset"><span id="step2B.i"><!-- Don't link to this legacy numbered ID. --></span> the <code>accumulated text</code> to the empty string.</li>
+                <li id="comp_labelledby_foreach"><span id="step2B.ii"><!-- Don't link to this legacy numbered ID. --></span> each IDREF:
                   <ol>
-                    <li id="comp_labelledby_set_current"><span id="step2B.ii.a"></span> the <code>current node</code> to the node referenced by the IDREF.</li>
-                    <li id="comp_labelledby_recursion"><span id="step2B.ii.b"></span><em>LabelledBy Recursion:</em> Compute the text alternative of the <code>current node</code> beginning with the overall <a href="#comp_computation">Computation</a> step. Set the <code>result</code> to that text alternative.</li>
-                    <li id="comp_labelledby_append"><span id="step2B.ii.c"></span> a space character and the <code>result</code> to the <code>accumulated text</code>.</li>
+                    <li id="comp_labelledby_set_current"><span id="step2B.ii.a"><!-- Don't link to this legacy numbered ID. --></span> the <code>current node</code> to the node referenced by the IDREF.</li>
+                    <li id="comp_labelledby_recursion"><span id="step2B.ii.b"><!-- Don't link to this legacy numbered ID. --></span><em>LabelledBy Recursion:</em> Compute the text alternative of the <code>current node</code> beginning with the overall <a href="#comp_computation">Computation</a> step. Set the <code>result</code> to that text alternative.</li>
+                    <li id="comp_labelledby_append"><span id="step2B.ii.c"><!-- Don't link to this legacy numbered ID. --></span> a space character and the <code>result</code> to the <code>accumulated text</code>.</li>
                   </ol>
                 </li>
-                <li id="comp_labelledby_return"><span id="step2B.iii"></span>Return the <code>accumulated text</code> if it is not the empty string ("").</li>
+                <li id="comp_labelledby_return"><span id="step2B.iii"><!-- Don't link to this legacy numbered ID. --></span>Return the <code>accumulated text</code> if it is not the empty string ("").</li>
               </ol>
               <div>
                 <p>The result of <a href="#comp_labelledby_recursion">LabelledBy Recursion</a> in combination with <a href="#comp_hidden_not_referenced">Hidden Not Referenced</a> means that <a class="termref">user agents</a> MUST include all nodes in the subtree as part of the <a class="termref">accessible name</a> or <a class="termref">accessible description</a>, when the node referenced by <code>aria-labelledby</code> or <code>aria-describedby</code> is hidden.</p>
@@ -422,7 +422,7 @@
                 </pre>
               </aside>
             </li>
-            <li id="comp_embedded_control"><span id="step2C"></span><em>Embedded Control:</em> Otherwise, if the <code>current node</code> is a control embedded within the label (e.g. any element directly referenced by <code>aria-labelledby</code>) for another <a class="termref">widget</a>, where the user can adjust the embedded control's value, then return the embedded control as part of the text alternative in the following manner:
+            <li id="comp_embedded_control"><span id="step2C"><!-- Don't link to this legacy numbered ID. --></span><em>Embedded Control:</em> Otherwise, if the <code>current node</code> is a control embedded within the label (e.g. any element directly referenced by <code>aria-labelledby</code>) for another <a class="termref">widget</a>, where the user can adjust the embedded control's value, then return the embedded control as part of the text alternative in the following manner:
               <ol>
                 <li id="comp_embedded_control_textbox"><em>Textbox:</em> If the embedded control has role <a class="role-reference" href="#textbox">textbox</a>, return its value.</li>
                 <li id="comp_embedded_control_combobox_or_listbox"><em>Combobox/Listbox:</em> If the embedded control has role <a class="role-reference" href="#combobox">combobox</a> or <a class="role-reference" href="#listbox">listbox</a>, return the text alternative of the chosen <a class="role-reference" href="#option">option</a>.</li>
@@ -442,7 +442,7 @@
 &lt;/label&gt;</code></pre>
               </aside>
             </li>
-            <li id="comp_label"><span id="step2D"></span><em>AriaLabel:</em> Otherwise, if the <code>current node</code> has an <code>aria-label</code> [=attribute=] whose value is not undefined, not the empty string, nor, when trimmed of [=ascii whitespace|whitespace=], is not the empty string:
+            <li id="comp_label"><span id="step2D"><!-- Don't link to this legacy numbered ID. --></span><em>AriaLabel:</em> Otherwise, if the <code>current node</code> has an <code>aria-label</code> [=attribute=] whose value is not undefined, not the empty string, nor, when trimmed of [=ascii whitespace|whitespace=], is not the empty string:
               <ol>
                 <li>If traversal of the <code>current node</code> is due to recursion <strong>and</strong> the <code>current node</code> is an embedded control, ignore <code>aria-label</code> and skip to rule <a href="#comp_embedded_control">Embedded Control</a>.</li>
                 <li>Otherwise, return the value of <code>aria-label</code>.</li>
@@ -462,38 +462,38 @@
 &lt;/ul&gt;</code></pre>
                   </aside>
             </li>
-            <li id="comp_host_language_label"><span id="step2E"></span><em>Host Language Label:</em> Otherwise, if the <code>current node</code>'s native markup provides an [=attribute=] (e.g. <code>alt</code>) or [=element=] (e.g. HTML <code>label</code> or SVG <code>title</code>) that defines a text alternative, return that alternative in the form of a <code>flat string</code> as defined by the host language, unless the element is marked as presentational (<code>role="presentation"</code> or <code>role="none"</code>).
+            <li id="comp_host_language_label"><span id="step2E"><!-- Don't link to this legacy numbered ID. --></span><em>Host Language Label:</em> Otherwise, if the <code>current node</code>'s native markup provides an [=attribute=] (e.g. <code>alt</code>) or [=element=] (e.g. HTML <code>label</code> or SVG <code>title</code>) that defines a text alternative, return that alternative in the form of a <code>flat string</code> as defined by the host language, unless the element is marked as presentational (<code>role="presentation"</code> or <code>role="none"</code>).
               <div class="note">See <a href="https://www.w3.org/TR/html-aam-1.0/#accessible-name-and-description-computation">HTML-AAM</a>, <a href="https://www.w3.org/TR/svg-aam-1.0/#mapping_additional_nd">SVG-AAM</a>, or other host language documentation for more information on markup that defines a text alternative.</div>
               <div class="note">
                 <p>For example, in <abbr title="Hypertext Markup Language">HTML</abbr>, the <code>img</code> element's <code>alt</code> attribute defines a text alternative string, and the <code>label</code> element provides text for the referenced form element.  In <abbr title="SVG2">SVG2</abbr>, the <code>desc</code> and <code>title</code> elements provide a description of their parent element. </p>
               </div>
             </li>
-            <li id="comp_name_from_content"><span id="step2F"></span><em>Name From Content:</em> Otherwise, if the <code>current node's</code> <a class="termref">role</a> allows <a class="specref" href="#namefromcontent">name from content</a>, or if the <code>current node</code> is referenced by <code>aria-labelledby</code>, <code>aria-describedby</code>, or is a native host language text alternative [=element=] (e.g. <code>label</code> in HTML), or is a descendant of a native host language text alternative [=element=]:
+            <li id="comp_name_from_content"><span id="step2F"><!-- Don't link to this legacy numbered ID. --></span><em>Name From Content:</em> Otherwise, if the <code>current node's</code> <a class="termref">role</a> allows <a class="specref" href="#namefromcontent">name from content</a>, or if the <code>current node</code> is referenced by <code>aria-labelledby</code>, <code>aria-describedby</code>, or is a native host language text alternative [=element=] (e.g. <code>label</code> in HTML), or is a descendant of a native host language text alternative [=element=]:
               <ol>
-                <li id="comp_name_from_content_reset"><span id="step2F.i"></span><em>Name From Content Reset:</em> Set the <code>accumulated text</code> to the empty string.</li>
-                <li id="comp_name_from_content_pseudo_element"><span id="step2F.ii"></span><em>Name From Generated Content:</em> Check for <abbr title="Cascading Style Sheets">CSS</abbr> generated textual content associated with the <code>current node</code> and include it in the <code>accumulated text</code>. The <abbr title="Cascading Style Sheets">CSS</abbr> <a href="https://www.w3.org/TR/CSS2/generate.html#before-after-content"><code>::before</code> and <code>::after</code></a> pseudo elements [[!CSS2]] can provide textual content for [=element|elements=] that have a content model.
+                <li id="comp_name_from_content_reset"><span id="step2F.i"><!-- Don't link to this legacy numbered ID. --></span><em>Name From Content Reset:</em> Set the <code>accumulated text</code> to the empty string.</li>
+                <li id="comp_name_from_content_pseudo_element"><span id="step2F.ii"><!-- Don't link to this legacy numbered ID. --></span><em>Name From Generated Content:</em> Check for <abbr title="Cascading Style Sheets">CSS</abbr> generated textual content associated with the <code>current node</code> and include it in the <code>accumulated text</code>. The <abbr title="Cascading Style Sheets">CSS</abbr> <a href="https://www.w3.org/TR/CSS2/generate.html#before-after-content"><code>::before</code> and <code>::after</code></a> pseudo elements [[!CSS2]] can provide textual content for [=element|elements=] that have a content model.
                   <ol>
                     <li id="comp_name_from_content_pseudo_element_before">For <code>::before</code> pseudo elements, <a class="termref">User agents</a> MUST prepend <abbr title="Cascading Style Sheets">CSS</abbr> textual content, without a space, to the textual content of the <code>current node</code>. </li>
                     <li id="comp_name_from_content_pseudo_element_after">For <code>::after</code> pseudo elements, <a class="termref">User agents</a> MUST append <abbr title="Cascading Style Sheets">CSS</abbr> textual content, without a space, to the textual content of the <code>current node</code>. </li>
                   </ol>
                 </li>
-                <li id="comp_name_from_content_for_each_child"><span id="step2F.iii"></span><em>Name From Each Child:</em> For each child node of the <code>current node</code>:
+                <li id="comp_name_from_content_for_each_child"><span id="step2F.iii"><!-- Don't link to this legacy numbered ID. --></span><em>Name From Each Child:</em> For each child node of the <code>current node</code>:
                   <ol>
-                    <li id="comp_name_from_content_for_each_child_set_current"><span id="step2F.iii.a"></span>Set the <code>current node</code> to the child node.</li>
-                    <li id="comp_name_from_content_for_each_child_recursion"><span id="step2F.iii.b"></span>Compute the text alternative of the  <code>current node</code> beginning with the overall <a href="#comp_computation">Computation</a> step. Set the <code>result</code> to that text alternative.</li>
-                    <li id="comp_for_each_child_append"><span id="step2F.iii.c"></span>Append the <code>result</code> to the <code>accumulated text</code>. </li>
+                    <li id="comp_name_from_content_for_each_child_set_current"><span id="step2F.iii.a"><!-- Don't link to this legacy numbered ID. --></span>Set the <code>current node</code> to the child node.</li>
+                    <li id="comp_name_from_content_for_each_child_recursion"><span id="step2F.iii.b"><!-- Don't link to this legacy numbered ID. --></span>Compute the text alternative of the  <code>current node</code> beginning with the overall <a href="#comp_computation">Computation</a> step. Set the <code>result</code> to that text alternative.</li>
+                    <li id="comp_for_each_child_append"><span id="step2F.iii.c"><!-- Don't link to this legacy numbered ID. --></span>Append the <code>result</code> to the <code>accumulated text</code>. </li>
                   </ol>
                 </li>
-                <li id="comp_name_from_content_return"><span id="step2F.iv"></span>Return the <code>accumulated text</code> if it is not the empty string ("").</li>
+                <li id="comp_name_from_content_return"><span id="step2F.iv"><!-- Don't link to this legacy numbered ID. --></span>Return the <code>accumulated text</code> if it is not the empty string ("").</li>
               </ol>
               <p><strong>Important</strong>:  Each [=nodes|node=] in the subtree is consulted only once. If text has been collected from a descendant, but is referenced by another IDREF in some descendant node, then that second, or subsequent, reference is not followed. This is done to avoid infinite loops.  </p>
               <div class="note">
                 <p>This step can apply to the child nodes themselves, which means the computation is recursive and results in text collected from all the elements in the <code>current node</code>'s subtree, no matter how deep it is. However, any given descendant [=nodes|node's=] text alternative can result from higher precedent markup described in steps B through D above, where "Namefrom: author" attributes provide the text alternative for the entire subtree. </p>
               </div>
             </li>
-            <li id="comp_text_node"><span id="step2G"></span><em>Text Node:</em> Otherwise, if the <code>current node</code> is a Text [=Node=], return its textual contents.</li>
-            <li id="comp_recursive_name_from_content"><span id="step2H"></span><em>Recursive Name From Content:</em> Otherwise, if the <code>current node</code> is a descendant of an element whose <a class="termref">Accessible Name</a> or <a class="termref">Accessible Description</a> is being computed, and contains descendants, proceed to <a href="#comp_name_from_content_reset">Name From Content Reset</a>.</li>
-            <li id="comp_tooltip"><span id="step2I"></span><em>Tooltip:</em> Otherwise, if the <code>current node</code> has a <a class="termref">Tooltip attribute</a>, return its value.
+            <li id="comp_text_node"><span id="step2G"><!-- Don't link to this legacy numbered ID. --></span><em>Text Node:</em> Otherwise, if the <code>current node</code> is a Text [=Node=], return its textual contents.</li>
+            <li id="comp_recursive_name_from_content"><span id="step2H"><!-- Don't link to this legacy numbered ID. --></span><em>Recursive Name From Content:</em> Otherwise, if the <code>current node</code> is a descendant of an element whose <a class="termref">Accessible Name</a> or <a class="termref">Accessible Description</a> is being computed, and contains descendants, proceed to <a href="#comp_name_from_content_reset">Name From Content Reset</a>.</li>
+            <li id="comp_tooltip"><span id="step2I"><!-- Don't link to this legacy numbered ID. --></span><em>Tooltip:</em> Otherwise, if the <code>current node</code> has a <a class="termref">Tooltip attribute</a>, return its value.
               <div class="note">
                 <p>Tooltip attributes are used only if nothing else, including subtree content, has provided results. </p>
               </div>

--- a/index.html
+++ b/index.html
@@ -398,8 +398,8 @@
             </li>
             <li id="comp_labelledby"><span id="step2B"><!-- Don't link to this legacy numbered ID. --></span><em>LabelledBy:</em> Otherwise, if the <code>current node</code> has an <code>aria-labelledby</code> [=attribute=] that contains at least one valid IDREF, and the <code>current node</code> is not already part of an ongoing <code>aria-labelledby</code> or <code>aria-describedby</code> traversal, process its IDREFs in the order they occur:
               <ol>
-                <li id="comp_labelledby_reset"><span id="step2B.i"><!-- Don't link to this legacy numbered ID. --></span> the <code>accumulated text</code> to the empty string.</li>
-                <li id="comp_labelledby_foreach"><span id="step2B.ii"><!-- Don't link to this legacy numbered ID. --></span> each IDREF:
+                <li id="comp_labelledby_reset"><span id="step2B.i"><!-- Don't link to this legacy numbered ID. --></span> Set the <code>accumulated text</code> to the empty string.</li>
+                <li id="comp_labelledby_foreach"><span id="step2B.ii"><!-- Don't link to this legacy numbered ID. --></span>For each IDREF:
                   <ol>
                     <li id="comp_labelledby_set_current"><span id="step2B.ii.a"><!-- Don't link to this legacy numbered ID. --></span> the <code>current node</code> to the node referenced by the IDREF.</li>
                     <li id="comp_labelledby_recursion"><span id="step2B.ii.b"><!-- Don't link to this legacy numbered ID. --></span><em>LabelledBy Recursion:</em> Compute the text alternative of the <code>current node</code> beginning with the overall <a href="#comp_computation">Computation</a> step. Set the <code>result</code> to that text alternative.</li>

--- a/index.html
+++ b/index.html
@@ -403,7 +403,7 @@
                   <ol>
                     <li id="comp_labelledby_set_current"><span id="step2B.ii.a"><!-- Don't link to this legacy numbered ID. --></span>Set the <code>current node</code> to the node referenced by the IDREF.</li>
                     <li id="comp_labelledby_recursion"><span id="step2B.ii.b"><!-- Don't link to this legacy numbered ID. --></span><em>LabelledBy Recursion:</em> Compute the text alternative of the <code>current node</code> beginning with the overall <a href="#comp_computation">Computation</a> step. Set the <code>result</code> to that text alternative.</li>
-                    <li id="comp_labelledby_append"><span id="step2B.ii.c"><!-- Don't link to this legacy numbered ID. --></span> a space character and the <code>result</code> to the <code>accumulated text</code>.</li>
+                    <li id="comp_labelledby_append"><span id="step2B.ii.c"><!-- Don't link to this legacy numbered ID. --></span>Append a space character and the <code>result</code> to the <code>accumulated text</code>.</li>
                   </ol>
                 </li>
                 <li id="comp_labelledby_return"><span id="step2B.iii"><!-- Don't link to this legacy numbered ID. --></span>Return the <code>accumulated text</code> if it is not the empty string ("").</li>

--- a/index.html
+++ b/index.html
@@ -357,10 +357,10 @@
       <h4>Computation steps</h4>
       <p>The text alternative for a given element is computed as follows:</p>
       <ol>
-        <li id="comp_init" name="step1"><em>Initialization:</em> Set the <code>root node</code> to the given element, the <code>current node</code> to the <code>root node</code>, and the <code>total accumulated text</code> to the empty string (""). If the <code>root node</code>'s role prohibits naming, return the empty string ("").</li>
-        <li id="comp_computation" name="step2"><em>Computation:</em> Compute the text alternative for the <code>current node</code>:
+        <li id="comp_init"><span id="step1"></span><em>Initialization:</em> Set the <code>root node</code> to the given element, the <code>current node</code> to the <code>root node</code>, and the <code>total accumulated text</code> to the empty string (""). If the <code>root node</code>'s role prohibits naming, return the empty string ("").</li>
+        <li id="comp_computation"><span id="step2"></span><em>Computation:</em> Compute the text alternative for the <code>current node</code>:
           <ol>
-            <li id="comp_hidden_not_referenced" name="step2A"><em>Hidden Not Referenced:</em> If the <code>current node</code> is <span class="informative">[=element/hidden=]</span> <strong>and is</strong>:
+            <li id="comp_hidden_not_referenced"><span id="step2A"></span><em>Hidden Not Referenced:</em> If the <code>current node</code> is <span class="informative">[=element/hidden=]</span> <strong>and is</strong>:
             <ol>
               <li><strong>Not</strong> part of an <code>aria-labelledby</code> or <code>aria-describedby</code> traversal, where the node directly referenced by that relation was hidden.</li>
               <li><strong>Nor</strong> part of a native host language text alternative <a class="termref">element</a> (e.g. <code>label</code> in HTML) or <a class="termref">attribute</a> traversal, where the root of that traversal was hidden.</li>
@@ -396,17 +396,17 @@
 &lt;/element2&gt;</code>
               </aside>
             </li>
-            <li id="comp_labelledby" name="step2B"><em>LabelledBy:</em> Otherwise, if the <code>current node</code> has an <code>aria-labelledby</code> [=attribute=] that contains at least one valid IDREF, and the <code>current node</code> is not already part of an ongoing <code>aria-labelledby</code> or <code>aria-describedby</code> traversal, process its IDREFs in the order they occur:
+            <li id="comp_labelledby"><span id="step2B"></span><em>LabelledBy:</em> Otherwise, if the <code>current node</code> has an <code>aria-labelledby</code> [=attribute=] that contains at least one valid IDREF, and the <code>current node</code> is not already part of an ongoing <code>aria-labelledby</code> or <code>aria-describedby</code> traversal, process its IDREFs in the order they occur:
               <ol>
-                <li id="comp_labelledby_reset" name="step2B.i">Set the <code>accumulated text</code> to the empty string.</li>
-                <li id="comp_labelledby_foreach" name="step2B.ii">For each IDREF:
+                <li id="comp_labelledby_reset"><span id="step2B.i"></span> the <code>accumulated text</code> to the empty string.</li>
+                <li id="comp_labelledby_foreach"><span id="step2B.ii"></span> each IDREF:
                   <ol>
-                    <li id="comp_labelledby_set_current" name="step2B.ii.a">Set the <code>current node</code> to the node referenced by the IDREF.</li>
-                    <li id="comp_labelledby_recursion" name="step2B.ii.b"><em>LabelledBy Recursion:</em> Compute the text alternative of the <code>current node</code> beginning with the overall <a href="#comp_computation">Computation</a> step. Set the <code>result</code> to that text alternative.</li>
-                    <li id="comp_labelledby_append" name="step2B.ii.c">Append a space character and the <code>result</code> to the <code>accumulated text</code>.</li>
+                    <li id="comp_labelledby_set_current"><span id="step2B.ii.a"></span> the <code>current node</code> to the node referenced by the IDREF.</li>
+                    <li id="comp_labelledby_recursion"><span id="step2B.ii.b"></span><em>LabelledBy Recursion:</em> Compute the text alternative of the <code>current node</code> beginning with the overall <a href="#comp_computation">Computation</a> step. Set the <code>result</code> to that text alternative.</li>
+                    <li id="comp_labelledby_append"><span id="step2B.ii.c"></span> a space character and the <code>result</code> to the <code>accumulated text</code>.</li>
                   </ol>
                 </li>
-                <li id="comp_labelledby_return" name="step2B.iii">Return the <code>accumulated text</code> if it is not the empty string ("").</li>
+                <li id="comp_labelledby_return"><span id="step2B.iii"></span>Return the <code>accumulated text</code> if it is not the empty string ("").</li>
               </ol>
               <div>
                 <p>The result of <a href="#comp_labelledby_recursion">LabelledBy Recursion</a> in combination with <a href="#comp_hidden_not_referenced">Hidden Not Referenced</a> means that <a class="termref">user agents</a> MUST include all nodes in the subtree as part of the <a class="termref">accessible name</a> or <a class="termref">accessible description</a>, when the node referenced by <code>aria-labelledby</code> or <code>aria-describedby</code> is hidden.</p>
@@ -422,7 +422,7 @@
                 </pre>
               </aside>
             </li>
-            <li id="comp_embedded_control" name="step2C"><em>Embedded Control:</em> Otherwise, if the <code>current node</code> is a control embedded within the label (e.g. any element directly referenced by <code>aria-labelledby</code>) for another <a class="termref">widget</a>, where the user can adjust the embedded control's value, then return the embedded control as part of the text alternative in the following manner:
+            <li id="comp_embedded_control"><span id="step2C"></span><em>Embedded Control:</em> Otherwise, if the <code>current node</code> is a control embedded within the label (e.g. any element directly referenced by <code>aria-labelledby</code>) for another <a class="termref">widget</a>, where the user can adjust the embedded control's value, then return the embedded control as part of the text alternative in the following manner:
               <ol>
                 <li id="comp_embedded_control_textbox"><em>Textbox:</em> If the embedded control has role <a class="role-reference" href="#textbox">textbox</a>, return its value.</li>
                 <li id="comp_embedded_control_combobox_or_listbox"><em>Combobox/Listbox:</em> If the embedded control has role <a class="role-reference" href="#combobox">combobox</a> or <a class="role-reference" href="#listbox">listbox</a>, return the text alternative of the chosen <a class="role-reference" href="#option">option</a>.</li>
@@ -442,7 +442,7 @@
 &lt;/label&gt;</code></pre>
               </aside>
             </li>
-            <li id="comp_label" name="step2D"><em>AriaLabel:</em> Otherwise, if the <code>current node</code> has an <code>aria-label</code> [=attribute=] whose value is not undefined, not the empty string, nor, when trimmed of [=ascii whitespace|whitespace=], is not the empty string:
+            <li id="comp_label"><span id="step2D"></span><em>AriaLabel:</em> Otherwise, if the <code>current node</code> has an <code>aria-label</code> [=attribute=] whose value is not undefined, not the empty string, nor, when trimmed of [=ascii whitespace|whitespace=], is not the empty string:
               <ol>
                 <li>If traversal of the <code>current node</code> is due to recursion <strong>and</strong> the <code>current node</code> is an embedded control, ignore <code>aria-label</code> and skip to rule <a href="#comp_embedded_control">Embedded Control</a>.</li>
                 <li>Otherwise, return the value of <code>aria-label</code>.</li>
@@ -462,38 +462,38 @@
 &lt;/ul&gt;</code></pre>
                   </aside>
             </li>
-            <li id="comp_host_language_label" name="step2E"><em>Host Language Label:</em> Otherwise, if the <code>current node</code>'s native markup provides an [=attribute=] (e.g. <code>alt</code>) or [=element=] (e.g. HTML <code>label</code> or SVG <code>title</code>) that defines a text alternative, return that alternative in the form of a <code>flat string</code> as defined by the host language, unless the element is marked as presentational (<code>role="presentation"</code> or <code>role="none"</code>).
+            <li id="comp_host_language_label"><span id="step2E"></span><em>Host Language Label:</em> Otherwise, if the <code>current node</code>'s native markup provides an [=attribute=] (e.g. <code>alt</code>) or [=element=] (e.g. HTML <code>label</code> or SVG <code>title</code>) that defines a text alternative, return that alternative in the form of a <code>flat string</code> as defined by the host language, unless the element is marked as presentational (<code>role="presentation"</code> or <code>role="none"</code>).
               <div class="note">See <a href="https://www.w3.org/TR/html-aam-1.0/#accessible-name-and-description-computation">HTML-AAM</a>, <a href="https://www.w3.org/TR/svg-aam-1.0/#mapping_additional_nd">SVG-AAM</a>, or other host language documentation for more information on markup that defines a text alternative.</div>
               <div class="note">
                 <p>For example, in <abbr title="Hypertext Markup Language">HTML</abbr>, the <code>img</code> element's <code>alt</code> attribute defines a text alternative string, and the <code>label</code> element provides text for the referenced form element.  In <abbr title="SVG2">SVG2</abbr>, the <code>desc</code> and <code>title</code> elements provide a description of their parent element. </p>
               </div>
             </li>
-            <li id="comp_name_from_content" name="step2F"><em>Name From Content:</em> Otherwise, if the <code>current node's</code> <a class="termref">role</a> allows <a class="specref" href="#namefromcontent">name from content</a>, or if the <code>current node</code> is referenced by <code>aria-labelledby</code>, <code>aria-describedby</code>, or is a native host language text alternative [=element=] (e.g. <code>label</code> in HTML), or is a descendant of a native host language text alternative [=element=]:
+            <li id="comp_name_from_content"><span id="step2F"></span><em>Name From Content:</em> Otherwise, if the <code>current node's</code> <a class="termref">role</a> allows <a class="specref" href="#namefromcontent">name from content</a>, or if the <code>current node</code> is referenced by <code>aria-labelledby</code>, <code>aria-describedby</code>, or is a native host language text alternative [=element=] (e.g. <code>label</code> in HTML), or is a descendant of a native host language text alternative [=element=]:
               <ol>
-                <li id="comp_name_from_content_reset" name="step2F.i"><em>Name From Content Reset:</em> Set the <code>accumulated text</code> to the empty string.</li>
-                <li id="comp_name_from_content_pseudo_element" name="step2F.ii"><em>Name From Generated Content:</em> Check for <abbr title="Cascading Style Sheets">CSS</abbr> generated textual content associated with the <code>current node</code> and include it in the <code>accumulated text</code>. The <abbr title="Cascading Style Sheets">CSS</abbr> <a href="https://www.w3.org/TR/CSS2/generate.html#before-after-content"><code>::before</code> and <code>::after</code></a> pseudo elements [[!CSS2]] can provide textual content for [=element|elements=] that have a content model.
+                <li id="comp_name_from_content_reset"><span id="step2F.i"></span><em>Name From Content Reset:</em> Set the <code>accumulated text</code> to the empty string.</li>
+                <li id="comp_name_from_content_pseudo_element"><span id="step2F.ii"></span><em>Name From Generated Content:</em> Check for <abbr title="Cascading Style Sheets">CSS</abbr> generated textual content associated with the <code>current node</code> and include it in the <code>accumulated text</code>. The <abbr title="Cascading Style Sheets">CSS</abbr> <a href="https://www.w3.org/TR/CSS2/generate.html#before-after-content"><code>::before</code> and <code>::after</code></a> pseudo elements [[!CSS2]] can provide textual content for [=element|elements=] that have a content model.
                   <ol>
                     <li id="comp_name_from_content_pseudo_element_before">For <code>::before</code> pseudo elements, <a class="termref">User agents</a> MUST prepend <abbr title="Cascading Style Sheets">CSS</abbr> textual content, without a space, to the textual content of the <code>current node</code>. </li>
                     <li id="comp_name_from_content_pseudo_element_after">For <code>::after</code> pseudo elements, <a class="termref">User agents</a> MUST append <abbr title="Cascading Style Sheets">CSS</abbr> textual content, without a space, to the textual content of the <code>current node</code>. </li>
                   </ol>
                 </li>
-                <li id="comp_name_from_content_for_each_child" name="step2F.iii"><em>Name From Each Child:</em> For each child node of the <code>current node</code>:
+                <li id="comp_name_from_content_for_each_child"><span id="step2F.iii"></span><em>Name From Each Child:</em> For each child node of the <code>current node</code>:
                   <ol>
-                    <li id="comp_name_from_content_for_each_child_set_current" name="step2F.iii.a">Set the <code>current node</code> to the child node.</li>
-                    <li id="comp_name_from_content_for_each_child_recursion" name="step2F.iii.b">Compute the text alternative of the  <code>current node</code> beginning with the overall <a href="#comp_computation">Computation</a> step. Set the <code>result</code> to that text alternative.</li>
-                    <li id="comp_for_each_child_append" name="step2F.iii.c">Append the <code>result</code> to the <code>accumulated text</code>. </li>
+                    <li id="comp_name_from_content_for_each_child_set_current"><span id="step2F.iii.a"></span>Set the <code>current node</code> to the child node.</li>
+                    <li id="comp_name_from_content_for_each_child_recursion"><span id="step2F.iii.b"></span>Compute the text alternative of the  <code>current node</code> beginning with the overall <a href="#comp_computation">Computation</a> step. Set the <code>result</code> to that text alternative.</li>
+                    <li id="comp_for_each_child_append"><span id="step2F.iii.c"></span>Append the <code>result</code> to the <code>accumulated text</code>. </li>
                   </ol>
                 </li>
-                <li id="comp_name_from_content_return" name="step2F.iv">Return the <code>accumulated text</code> if it is not the empty string ("").</li>
+                <li id="comp_name_from_content_return"><span id="step2F.iv"></span>Return the <code>accumulated text</code> if it is not the empty string ("").</li>
               </ol>
               <p><strong>Important</strong>:  Each [=nodes|node=] in the subtree is consulted only once. If text has been collected from a descendant, but is referenced by another IDREF in some descendant node, then that second, or subsequent, reference is not followed. This is done to avoid infinite loops.  </p>
               <div class="note">
                 <p>This step can apply to the child nodes themselves, which means the computation is recursive and results in text collected from all the elements in the <code>current node</code>'s subtree, no matter how deep it is. However, any given descendant [=nodes|node's=] text alternative can result from higher precedent markup described in steps B through D above, where "Namefrom: author" attributes provide the text alternative for the entire subtree. </p>
               </div>
             </li>
-            <li id="comp_text_node" name="step2G"><em>Text Node:</em> Otherwise, if the <code>current node</code> is a Text [=Node=], return its textual contents.</li>
-            <li id="comp_recursive_name_from_content" name="step2H"><em>Recursive Name From Content:</em> Otherwise, if the <code>current node</code> is a descendant of an element whose <a class="termref">Accessible Name</a> or <a class="termref">Accessible Description</a> is being computed, and contains descendants, proceed to <a href="#comp_name_from_content_reset">Name From Content Reset</a>.</li>
-            <li id="comp_tooltip" name="step2I"><em>Tooltip:</em> Otherwise, if the <code>current node</code> has a <a class="termref">Tooltip attribute</a>, return its value.
+            <li id="comp_text_node"><span id="step2G"></span><em>Text Node:</em> Otherwise, if the <code>current node</code> is a Text [=Node=], return its textual contents.</li>
+            <li id="comp_recursive_name_from_content"><span id="step2H"></span><em>Recursive Name From Content:</em> Otherwise, if the <code>current node</code> is a descendant of an element whose <a class="termref">Accessible Name</a> or <a class="termref">Accessible Description</a> is being computed, and contains descendants, proceed to <a href="#comp_name_from_content_reset">Name From Content Reset</a>.</li>
+            <li id="comp_tooltip"><span id="step2I"></span><em>Tooltip:</em> Otherwise, if the <code>current node</code> has a <a class="termref">Tooltip attribute</a>, return its value.
               <div class="note">
                 <p>Tooltip attributes are used only if nothing else, including subtree content, has provided results. </p>
               </div>


### PR DESCRIPTION
Fixes #214


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/accname/pull/219.html" title="Last updated on Nov 4, 2023, 3:34 AM UTC (ab9b86f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/accname/219/3e8f6d4...ab9b86f.html" title="Last updated on Nov 4, 2023, 3:34 AM UTC (ab9b86f)">Diff</a>