### PR TITLE
editorial: remove contributors include

### DIFF
--- a/index.html
+++ b/index.html
@@ -532,7 +532,6 @@
     <h3>Acknowledgments</h3>
     <p>The following people contributed to the development of this document.</p>
     <div data-include="common/acknowledgements/aria-wg-active.html" data-include-replace="true"></div>
-    <div data-include="common/acknowledgements/aria-contributors.html" data-include-replace="true"></div>
     <div data-include="common/acknowledgements/funders.html" data-include-replace="true"></div>
   </section>
 </section>


### PR DESCRIPTION
Cf. https://github.com/w3c/aria-common/issues/103

If preferred, I can add the alternative (using the github contributors) as we did in https://github.com/w3c/aria/pull/1993/


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/accname/pull/224.html" title="Last updated on Dec 11, 2023, 6:03 PM UTC (b649702)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/accname/224/cf77505...b649702.html" title="Last updated on Dec 11, 2023, 6:03 PM UTC (b649702)">Diff</a>