### PR TITLE
Add assistive technology definition to prevent broken link to ARIA 1.2

### DIFF
--- a/index.html
+++ b/index.html
@@ -208,6 +208,25 @@
 	<div>
 		<p>While some terms are defined in place, the following definitions are used throughout this document. </p>
 		<dl class="termlist">
+      <dt><dfn data-lt="assistive technologies|assistive technology">Assistive Technologies</dfn></dt>
+      <dd><p>Hardware and/or software that:</p>
+        <ul>
+          <li>relies on services provided by a <a>user agent</a> to retrieve and render Web content </li>
+          <li>works with a user agent or web content itself through the use of APIs, and</li>
+          <li>provides services beyond those offered by the user agent to facilitate user interaction with web content by people with disabilities</li>
+        </ul>
+        <p>This definition may differ from that used in other documents.</p>
+      <p>Examples of assistive technologies that are important in the context
+        of this document include the following:</p>
+      <ul>
+        <li>screen magnifiers, which are used to enlarge and improve the visual readability of rendered text and images;</li>
+        <li>screen readers, which are most-often used to convey information through synthesized speech or a refreshable Braille display;</li>
+        <li>text-to-speech software, which is used to convert text into synthetic speech;</li>
+        <li>speech recognition software, which is used to allow spoken control and dictation;</li>
+        <li>alternate input technologies (including head pointers, on-screen keyboards, single switches, and sip/puff devices), which are used to simulate the keyboard;</li>
+        <li>alternate pointing devices, which are used to simulate mouse pointing and clicking.</li>
+      </ul>
+      </dd>
       <dt><dfn data-export="">Accessible Description</dfn></dt>
 			<dd>
 			  <p>An accessible description provides additional information, related to an interface element, that complements the <a>accessible name</a>. The accessible description might or might not be visually perceivable. </p>


### PR DESCRIPTION
This document has local definitions of accessible name, accessible description, and others. However, it does not  have local definition for "assistive technologies". That triggers aria-common scripts that resort to what's in WAI-ARIA 1.2. But that fails, because in WAI-ARIA 1.2 we have #dfn-assistive-technology instead of #dfn-assistive-technologies.

This adds the definition of assistive technologies back to the AccName spec. @accdc @MelSumner  let me know if that works for you or there's a specific reason why we do want to point specifically to WAI-ARIA 1.2 for the assistive technology definition while we are pointing to AccName for accessible name, accessible description, and others.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/accname/pull/228.html" title="Last updated on Jan 25, 2024, 5:46 PM UTC (84f0865)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/accname/228/72e4f2c...84f0865.html" title="Last updated on Jan 25, 2024, 5:46 PM UTC (84f0865)">Diff</a>