### PR TITLE
feat: update step 2F to exclude nodes referenced by aria-actions

### DIFF
--- a/index.html
+++ b/index.html
@@ -508,6 +508,8 @@
                 </li>
                 <li id="comp_name_from_content_for_each_child"><span id="step2F.iii"><!-- Don't link to this legacy numbered ID. --></span><em>Name From Each Child:</em> For each <code>rendered child node</code> of the <code>current node</code>:
                   <ol>
+                    <li id="comp_name_from_content_find_child_actions">If the <code>current node</code> has an <code>aria-actions</code> [=attribute=] with an IDREF matching the rendered child node, skip steps b-d for this child node.</li>
+                    <li>If the <code>current node</code> has an <code>aria-actions</code> [=attribute=] with at least one valid IDREF matching any of the descendents of the rendered child node, exclude the referenced descendants from the name from content of the <code>current node</code>.</li>
                     <li id="comp_name_from_content_for_each_child_set_current"><span id="step2F.iii.a"><!-- Don't link to this legacy numbered ID. --></span>Set the <code>current node</code> to the <code>rendered child node</code>.</li>
                     <li id="comp_name_from_content_for_each_child_recursion"><span id="step2F.iii.b"><!-- Don't link to this legacy numbered ID. --></span>Compute the text alternative of the  <code>current node</code> beginning with the overall <a href="#comp_computation">Computation</a> step. Set the <code>result</code> to that text alternative.</li>
                     <li id="comp_for_each_child_append"><span id="step2F.iii.c"><!-- Don't link to this legacy numbered ID. --></span>Append the <code>result</code> to the <code>accumulated text</code>. </li>


### PR DESCRIPTION
Context at https://github.com/w3c/aria/pull/1805, and this PR should not be merged before the ARIA PR.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/accname/pull/235.html" title="Last updated on Apr 19, 2024, 8:19 PM UTC (87e5c69)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/accname/235/3116a92...87e5c69.html" title="Last updated on Apr 19, 2024, 8:19 PM UTC (87e5c69)">Diff</a>