### PR TITLE
Renaming LabelledBy Recursion since this step is not actually recursive.

### DIFF
--- a/index.html
+++ b/index.html
@@ -423,14 +423,14 @@
                 <li id="comp_labelledby_foreach"><span id="step2B.ii"><!-- Don't link to this legacy numbered ID. --></span>For each IDREF:
                   <ol>
                     <li id="comp_labelledby_set_current"><span id="step2B.ii.a"><!-- Don't link to this legacy numbered ID. --></span>Set the <code>current node</code> to the node referenced by the IDREF.</li>
-                    <li id="comp_labelledby_recursion"><span id="step2B.ii.b"><!-- Don't link to this legacy numbered ID. --></span><em>LabelledBy Recursion:</em> Compute the text alternative of the <code>current node</code> beginning with the overall <a href="#comp_computation">Computation</a> step. Set the <code>result</code> to that text alternative.</li>
+                    <li id="comp_labelledby_traversal"><span id="step2B.ii.b"><!-- Don't link to this legacy numbered ID. --></span><em>LabelledBy Traversal:</em> Compute the text alternative of the <code>current node</code> beginning with the overall <a href="#comp_computation">Computation</a> step. Set the <code>result</code> to that text alternative.</li>
                     <li id="comp_labelledby_append"><span id="step2B.ii.c"><!-- Don't link to this legacy numbered ID. --></span>Append a space character and the <code>result</code> to the <code>accumulated text</code>.</li>
                   </ol>
                 </li>
                 <li id="comp_labelledby_return"><span id="step2B.iii"><!-- Don't link to this legacy numbered ID. --></span>Return the <code>accumulated text</code> if it is not the empty string ("").</li>
               </ol>
               <div>
-                <p>The result of <a href="#comp_labelledby_recursion">LabelledBy Recursion</a> in combination with <a href="#comp_hidden_not_referenced">Hidden Not Referenced</a> means that <a class="termref">user agents</a> MUST include all nodes in the subtree as part of the <a class="termref">accessible name</a> or <a class="termref">accessible description</a>, when the node referenced by <code>aria-labelledby</code> or <code>aria-describedby</code> is hidden.</p>
+                <p>The result of <a href="#comp_labelledby_traversal">LabelledBy Traversal</a> in combination with <a href="#comp_hidden_not_referenced">Hidden Not Referenced</a> means that <a class="termref">user agents</a> MUST include all nodes in the subtree as part of the <a class="termref">accessible name</a> or <a class="termref">accessible description</a>, when the node referenced by <code>aria-labelledby</code> or <code>aria-describedby</code> is hidden.</p>
               <aside class="example">
                 <p>The following example shows the meaning of the clause "&#8230; and the <code>current node</code> is not already part of an <code>aria-labelledby</code> traversal &#8230;" .</p>
                 <ol>
@@ -465,7 +465,7 @@
             </li>
             <li id="comp_label"><span id="step2D"><!-- Don't link to this legacy numbered ID. --></span><em>AriaLabel:</em> Otherwise, if the <code>current node</code> has an <code>aria-label</code> [=attribute=] whose value is not undefined, not the empty string, nor, when trimmed of [=ascii whitespace|whitespace=], is not the empty string:
               <ol>
-                <li>If traversal of the <code>current node</code> is due to recursion <strong>and</strong> the <code>current node</code> is an embedded control, ignore <code>aria-label</code> and skip to rule <a href="#comp_embedded_control">Embedded Control</a>.</li>
+                <li>If traversal of the <code>current node</code> is due to <a href="#comp_name_from_content_for_each_child">Name From Content descendant node recursion</a> <strong>and</strong> the <code>current node</code> is an embedded control, ignore <code>aria-label</code> and skip to rule <a href="#comp_embedded_control">Embedded Control</a>.</li>
                 <li>Otherwise, return the value of <code>aria-label</code>.</li>
               </ol>
               <aside class="example">


### PR DESCRIPTION
Closes #222

<!--- IF EDITORIAL or CHORE, delete the rest of this template -->

Renaming "LabelledBy Recursion" to "LabelledBy Traversal" since this step is not actually recursive.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/accname/pull/236.html" title="Last updated on May 1, 2024, 6:37 PM UTC (5e8c01f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/accname/236/621e3bc...5e8c01f.html" title="Last updated on May 1, 2024, 6:37 PM UTC (5e8c01f)">Diff</a>